### PR TITLE
Support the OpenSSL “pass zero for strlen” when setting X.509 hostnames.

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -89,6 +89,14 @@ static int int_x509_param_set_hosts(X509_VERIFY_PARAM_ID *id, int mode,
 {
     char *copy;
 
+    // This is an OpenSSL quirk that BoringSSL typically doesn't support.
+    // However, we didn't make this a fatal error at the time, which was a
+    // mistake. Because of that, given the risk that someone could assume the
+    // OpenSSL semantics from BoringSSL, it's supported in this case.
+    if (name != NULL && namelen == 0) {
+        namelen = strlen(name);
+    }
+
     /*
      * Refuse names with embedded NUL bytes.
      * XXX: Do we need to push an error onto the error stack?


### PR DESCRIPTION
BoringSSL does not generally support this quirk but, in this case, we
didn't make it a fatal error and it's instead a silent omission of
hostname checking. This doesn't affect Chrome but, in case something is
using BoringSSL and using this trick, this change makes it safe.

BUG=chromium:824799

Change-Id: If417817b997b9faa9963c09dfc95d06a5d445e0b
Reviewed-on: https://boringssl-review.googlesource.com/26724
Commit-Queue: Adam Langley <alangley@gmail.com>
Commit-Queue: David Benjamin <davidben@google.com>
Reviewed-by: David Benjamin <davidben@google.com>
CQ-Verified: CQ bot account: commit-bot@chromium.org <commit-bot@chromium.org>

Please do not send pull requests to the BoringSSL repository.

We do, however, take contributions gladly.

See https://boringssl.googlesource.com/boringssl/+/master/CONTRIBUTING.md

Thanks!
